### PR TITLE
Add Sengled Element Classic (A60) - B22 fitting

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -1171,8 +1171,8 @@ const devices = [
         toZigbee: generic.light_onoff_brightness().toZigbee,
     },
     {
-        zigbeeModel: ['E11-G23'],
-        model: 'E11-G23',
+        zigbeeModel: ['E11-G23','E11-G33'],
+        model: 'E11-G23/E11-G33',
         vendor: 'Sengled',
         description: 'Element Classic (A60)',
         supports: generic.light_onoff_brightness().supports,


### PR DESCRIPTION
The Sengled Element Classic with Edison fitting (E27) is already defined - model E11-G23.  The same bulb comes with a bayonet fitting (B22) with a slightly different model number - E11-G33.